### PR TITLE
Fix the filter which does not work for v2 protocol

### DIFF
--- a/models/nft/wyvern_data.sql
+++ b/models/nft/wyvern_data.sql
@@ -50,10 +50,7 @@ wyvern_data as (
     end as token_id
 
   from wyvern_atomic_match
-  where
-    (addrs[3] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073'
-      or addrs[10] = '0x5b3256965e7c3cf26e11fcaf296dfc8807c01073')
-    and call_success = true
+  where call_success = true
 )
 
 select


### PR DESCRIPTION
This filter perfectly work for v1 but not work for v2 (addrs[3] and addrs[10] probably be null)