### PR TITLE
feat: cast the integer string type to bigint type

### DIFF
--- a/models/nft/nft_trades.sql
+++ b/models/nft/nft_trades.sql
@@ -38,5 +38,5 @@ final as (
   from opensea_trades
 )
 
-select /*+ REPARTITION(1) */ *
+select /*+ REPARTITION(50) */ *
 from final

--- a/models/nft/wyvern_data.sql
+++ b/models/nft/wyvern_data.sql
@@ -20,7 +20,7 @@ wyvern_data as (
     addrs[1] as buyer,
     {{ binary_to_address(substring('calldatabuy', 49, 20)) }} as buyer_when_aggr,
     addrs[8] as seller,
-    uints[4] as currency_amount,
+    bigint(uints[4]) as currency_amount,
     case
       when {{ substring('calldatabuy', 1, 4) }} in ({{ binary_literal('68f0bcaa') }}) then 'Bundle Trade'
       else 'Single Item Trade'

--- a/packages.yml
+++ b/packages.yml
@@ -3,4 +3,4 @@ packages:
     version: 0.8.4
 
   - git: "https://github.com/datawaves-xyz/dbt_ethereum_source"
-    revision: 0.1.5
+    revision: 0.1.6


### PR DESCRIPTION
- upgrade the source package to 0.1.6
- cast the integer string type in the contract table to bigint type
- modify the partition number of nft_trades to 50
  - why 50? nft_trades now has 4G and each partition can be divided into 80MB. Spark's best practice recommends that each partition be around 100-200MB in size, so 50 partitions can handle 2-3 times the data growth. We are just trying to get a balance partition, so it doesn't make a difference if we add the partition key or not, but the number of partitions must be added, otherwise, it will be partitioned according to `spark.sql.shuffle.partitions`(500).