### PR TITLE
User external sources for nft metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Try running integration tests for utils:
 - dbt test
 
 
+Refresh external tables:
+
+- dbt run-operation stage_external_sources --vars "ext_full_refresh: true"
+
 ## Operations
 
 Backfill the history/single date of an incremental model

--- a/models/nft_metadata/sources.yml
+++ b/models/nft_metadata/sources.yml
@@ -1,0 +1,23 @@
+version: 2
+
+sources:
+  - name: ethereum_nft_metadata
+    tables:
+      - name: otherdeed_kodas
+        external:
+          location: s3a://ifcrypto/external/nft_metadata/otherdeed_kodas
+          using: csv 
+          options:
+            header: 'true'
+      - name: otherdeed_lands
+        external:
+          location: s3a://ifcrypto/external/nft_metadata/otherdeed_lands
+          using: csv 
+          options:
+            header: 'true'
+      - name: cryptocoven
+        external:
+          location: s3a://ifcrypto/external/nft_metadata/cryptocoven
+          using: csv 
+          options:
+            header: 'true'

--- a/packages.yml
+++ b/packages.yml
@@ -4,3 +4,6 @@ packages:
 
   - git: "https://github.com/datawaves-xyz/dbt_ethereum_source"
     revision: 0.1.6
+
+  - package: dbt-labs/dbt_external_tables
+    version: 0.8.0


### PR DESCRIPTION
#15 is closed because uploading seed is extremely slow. I now use external sources for importing those metadata. 

Maybe we can use dbt seed  for managing NFT metadata when we figure out a performant way to insert tables in Hive.