### PR TITLE
Union all modeling labels into a single materialized table

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,7 +18,6 @@ models:
       +materialized: view      
     labels:
       +schema: labels
-      +materialized: view
       +tags:
         - chain_ethereum
         - level_modeling

--- a/models/labels/labels.sql
+++ b/models/labels/labels.sql
@@ -1,0 +1,20 @@
+{{
+  cte_import([
+    ('nft_whale', 'nft_whale'),
+    ('smart_nft_trader', 'smart_nft_trader'),
+  ])
+}}
+
+select
+  address,
+  label,
+  label_type
+from smart_nft_trader
+
+union all
+
+select
+  address,
+  label,
+  label_type
+from nft_whale

--- a/models/labels/schema.yml
+++ b/models/labels/schema.yml
@@ -1,5 +1,13 @@
 version: 2
 
 models:
+  - name: labels
+    config:
+      materialized: table
+      file_format: parquet
   - name: nft_whale
+    config:
+      materialized: ephemeral
   - name: smart_nft_trader
+    config:
+      materialized: ephemeral  


### PR DESCRIPTION
I also changed two nft wallet labels to [ephemeral](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/materializations#ephemeral) models.

###  How to use

```sql
select
    to_date(block_time) as dt,
    -sum(usd_amount) as volume
from ethereum_nft.nft_trades t

join ethereum_labels.labels ll
    on nft_contract_address = '0x34d85c9cdeb23fa97cb08333b511ac86e1c4e258' 
        and ll.address = t.seller
        and ll.label = 'Smart NFT Trader'

where to_date(block_time) >= date_sub(current_date(),30)
group by dt
```